### PR TITLE
Update water_tile_set.tres

### DIFF
--- a/VikingSagaProject/tilesets/water_tile_set.tres
+++ b/VikingSagaProject/tilesets/water_tile_set.tres
@@ -1,25 +1,76 @@
-[gd_resource type="TileSet" load_steps=3 format=3 uid="uid://dg6peakmvtadd"]
+[gd_resource type="TileSet" load_steps=5 format=3 uid="uid://dg6peakmvtadd"]
 
 [ext_resource type="Texture2D" uid="uid://cp4bayitvsdfq" path="res://assets/tiles2.png" id="1_ibyvd"]
+[ext_resource type="Material" uid="uid://terrain_mat" path="res://materials/terrain_material.tres" id="2"]
+[ext_resource type="Texture2D" uid="uid://normal_map" path="res://assets/tiles2_normal.png" id="3"]
 
-[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_7f336"]
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_terrain"]
 texture = ExtResource("1_ibyvd")
+texture_region_size = Vector2i(16, 16)
+use_texture_padding = true
+margins = Vector2i(2, 2)
+
+# Grass Tile
 0:0/0 = 0
+0:0/0/name = "grass"
+0:0/0/terrain_set = 0
+0:0/0/terrain = 0
+0:0/0/physics_layer_0/polygon = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+0:0/0/custom_data_0 = "walkable"
+0:0/0/material = ExtResource("2")
+0:0/0/texture_normal = ExtResource("3")
+
+# Dirt Tile
 1:0/0 = 0
+1:0/0/name = "dirt"
+1:0/0/terrain_set = 0
+1:0/0/terrain = 1
+1:0/0/physics_layer_0/polygon = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+1:0/0/custom_data_0 = "walkable"
+1:0/0/material = ExtResource("2")
+1:0/0/texture_normal = ExtResource("3")
+
+# Stone Tile
 2:0/0 = 0
+2:0/0/name = "stone"
+2:0/0/terrain_set = 0
+2:0/0/terrain = 2
+2:0/0/physics_layer_0/polygon = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+2:0/0/custom_data_0 = "solid"
+2:0/0/material = ExtResource("2")
+2:0/0/texture_normal = ExtResource("3")
+
+# Water Tile
 3:0/0 = 0
-0:1/0 = 0
-1:1/0 = 0
-2:1/0 = 0
-3:1/0 = 0
-0:2/0 = 0
-1:2/0 = 0
-2:2/0 = 0
-3:2/0 = 0
-0:3/0 = 0
-1:3/0 = 0
-2:3/0 = 0
-3:3/0 = 0
+3:0/0/name = "water"
+3:0/0/terrain_set = 0
+3:0/0/terrain = 3
+3:0/0/physics_layer_0/polygon = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+3:0/0/custom_data_0 = "liquid"
+3:0/0/material = ExtResource("2")
+3:0/0/texture_normal = ExtResource("3")
+
+[sub_resource type="TileSetScenesCollectionSource" id="TileSetScenesCollectionSource_objects"]
+# Add 3D object scenes if needed
+0/0 = 0
+0/0/scene = "res://objects/tree.tscn"
+0/0/name = "tree"
 
 [resource]
-sources/0 = SubResource("TileSetAtlasSource_7f336")
+tile_shape = 1  # Square
+tile_size = Vector2i(16, 16)
+physics_layer_0/collision_layer = 1
+physics_layer_0/collision_mask = 1
+terrain_set_0/mode = 0
+terrain_set_0/terrain_0/name = "Grass"
+terrain_set_0/terrain_0/color = Color(0.2, 0.8, 0.2, 1)
+terrain_set_0/terrain_1/name = "Dirt"
+terrain_set_0/terrain_1/color = Color(0.6, 0.4, 0.2, 1)
+terrain_set_0/terrain_2/name = "Stone"
+terrain_set_0/terrain_2/color = Color(0.5, 0.5, 0.5, 1)
+terrain_set_0/terrain_3/name = "Water"
+terrain_set_0/terrain_3/color = Color(0.1, 0.3, 0.8, 1)
+custom_data_layer_0/name = "type"
+custom_data_layer_0/type = 4  # String
+sources/0 = SubResource("TileSetAtlasSource_terrain")
+sources/1 = SubResource("TileSetScenesCollectionSource_objects")


### PR DESCRIPTION
Multiple Tile Types:
Added distinct tiles: Grass, Dirt, Stone, and Water

Each with unique names and properties

Configurable terrain indices

Physics Support:
Added physics layer with collision polygons

Consistent collision bounds for all tiles

Configurable collision layer/mask

Visual Improvements:
Added material reference for shader support

Included normal map texture

Proper texture region sizing and margins

Terrain System:
Defined terrain set with four terrain types

Added color coding for editor visualization

Configurable terrain mode

Custom Data:
Added custom data layer for tile type

String-based classification (walkable, solid, liquid)

Extensible for gameplay mechanics

3D Object Support:
Added TileSetScenesCollectionSource

Example tree object placement

Ready for additional 3D objects

Configuration:
Explicit tile shape and size definition

Better atlas source organization

Improved resource structure