### PR TITLE
Create Movingentity.tscn

### DIFF
--- a/VikingSagaProject/settlements/MovingEntity.gd
+++ b/VikingSagaProject/settlements/MovingEntity.gd
@@ -1,26 +1,52 @@
-[gd_scene load_steps=3 format=3 uid="uid://moving_entity"]
+extends CharacterBody2D
 
-[ext_resource type="Script" path="res://MovingEntity.gd" id="1"]
-[ext_resource type="Texture2D" path="res://assets/entity_sprite.png" id="2"]
+@export var speed: float = 100.0
+@export var entity_name: String = "Default Name" : set = set_entity_name
 
-[node name="MovingEntity" type="Area2D"]
-script = ExtResource("1")
+@onready var sprite_2d: Sprite2D = $Sprite2D
+@onready var name_label: Label = $NameLabel
+@onready var animation_player: AnimationPlayer = $AnimationPlayer
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-texture = ExtResource("2")
+var current_animation: String = ""
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("CircleShape2D_abc")  # Add appropriate shape
+func _ready() -> void:
+    set_entity_name(entity_name) # Set initial name
+    # If not using autoplay in AnimationPlayer or want to control it here:
+    # play_animation("idle_pulse")
 
-[node name="Identity" type="Label" parent="."]
-offset_left = -20.0
-offset_top = -30.0
-offset_right = 20.0
-offset_bottom = -10.0
-text = "Village"
-horizontal_alignment = 1
+func set_entity_name(new_name: String) -> void:
+    entity_name = new_name
+    if name_label:
+        name_label.text = entity_name
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-libraries = {
-    "": SubResource("AnimationLibrary_xyz")
-}
+func _physics_process(delta: float) -> void:
+    # Example movement (replace with your actual logic)
+    var direction := Vector2.ZERO
+    if Input.is_action_pressed("ui_right"):
+        direction.x += 1
+    if Input.is_action_pressed("ui_left"):
+        direction.x -= 1
+    if Input.is_action_pressed("ui_down"):
+        direction.y += 1
+    if Input.is_action_pressed("ui_up"):
+        direction.y -= 1
+
+    if direction != Vector2.ZERO:
+        velocity = direction.normalized() * speed
+        play_animation("walk") # Assumes you have a walk animation
+        # Flip sprite based on direction
+        if direction.x != 0:
+            sprite_2d.flip_h = direction.x < 0
+    else:
+        velocity = Vector2.ZERO
+        play_animation("idle_pulse") # Assumes you have an idle animation
+
+    move_and_slide()
+
+func play_animation(anim_name: String) -> void:
+    if animation_player and animation_player.has_animation(anim_name):
+        if current_animation != anim_name: # Only play if it's a new animation
+            animation_player.play(anim_name)
+            current_animation = anim_name
+    else:
+        printerr("AnimationPlayer or animation not found: ", anim_name)

--- a/VikingSagaProject/settlements/Movingentity.tscn
+++ b/VikingSagaProject/settlements/Movingentity.tscn
@@ -1,0 +1,99 @@
+[gd_scene load_steps=7 format=3 uid="uid://b1a2s3d4e5f6_moving_entity"]
+
+[ext_resource type="Script" path="res://MovingEntity.gd" id="1_abcde"]
+[ext_resource type="Texture2D" path="res://assets/entity_sprite.png" id="2_fghij"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_collider"]
+radius = 8.0 # Adjust radius based on your sprite size
+
+[sub_resource type="Animation" id="Animation_idle_pulse"]
+resource_name = "idle_pulse"
+length = 1.0
+loop_mode = 1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprite2D:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.5, 1),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(1.1, 1.1), Vector2(1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_walk"]
+resource_name = "walk"
+length = 0.4
+loop_mode = 1
+step = 0.1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprite2D:frame") # Assumes your Sprite2D texture is a spritesheet
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.2, 0.3),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1, # Discrete updates for frame changes
+"values": [0, 1, 2, 3] # Example: 4 frames for walking
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Sprite2D:hframes") # Set hframes if not already set on Sprite2D node
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [4] # Assuming 4 horizontal frames in your spritesheet
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_entity_anims"]
+_data = {
+"idle_pulse": SubResource("Animation_idle_pulse"),
+"walk": SubResource("Animation_walk")
+}
+
+[node name="MovingEntity" type="CharacterBody2D"] # Changed to CharacterBody2D
+script = ExtResource("1_abcde")
+# Optional: define collision layers/masks if needed
+# collision_layer = 1
+# collision_mask = 1
+# motion_mode = 1 # 0 for GROUNDED, 1 for FLOATING
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("2_fghij")
+# If your sprite isn't centered by default, you might want:
+# centered = true
+# Or adjust offset:
+# offset = Vector2(0, -8) # Example: if origin should be at feet
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_collider")
+
+[node name="NameLabel" type="Label" parent="."] # Renamed for clarity
+offset_left = -25.0
+offset_top = -25.0 # Adjusted to be above a typical small sprite
+offset_right = 25.0
+offset_bottom = -12.0
+text = "Entity" # Generic placeholder, set by script
+horizontal_alignment = 1 # Center alignment
+vertical_alignment = 1   # Middle alignment (if you add more height)
+# For better readability, you might want to add theme overrides in the inspector
+# or via code, e.g., for font size, outline.
+# theme_override_font_sizes/font_size = 8
+# theme_override_colors/font_color = Color(1, 1, 1, 1)
+# theme_override_constants/outline_size = 1
+# theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_entity_anims")
+}
+autoplay = "idle_pulse" # Optional: play an animation by default


### PR DESCRIPTION
UID: uid="uid://b1a2s3d4e5f6_moving_entity" - I've made the UID slightly more unique-looking, though Godot generates these. The main thing is it's there. ExtResource IDs: id="1_abcde", id="2_fghij" - Added some suffix to make them slightly more distinct from plain numbers, which can be good practice if you have many resources. Root Node Type: Changed from Area2D to CharacterBody2D. This is a significant upgrade if the entity needs to interact with the physics world for movement (e.g., move_and_slide()). Added comments for collision_layer, collision_mask, and motion_mode which are common CharacterBody2D properties. CollisionShape2D Defined:
[sub_resource type="CircleShape2D" id="CircleShape2D_collider"] now defines the shape. radius = 8.0 is an example; adjust this to fit your entity_sprite.png. NameLabel (was Identity):
Renamed to NameLabel for better clarity.
offset_top adjusted to position it typically above a small sprite. text = "Entity" is a more generic placeholder.
Added comments about theme_override_ properties for styling the label, which is a common need. AnimationPlayer & Library:
[sub_resource type="AnimationLibrary" id="AnimationLibrary_entity_anims"] defines the library. Added an example Animation_idle_pulse that scales the Sprite2D up and down slightly. Added an example Animation_walk that animates Sprite2D:frame and sets Sprite2D:hframes. This assumes your entity_sprite.png is a horizontal sprite sheet for walking. If it's not, you'll need to adjust or remove the "walk" animation. AnimationPlayer now references this library.
autoplay = "idle_pulse" makes the entity play the idle animation by default when it enters the scene. Sprite2D:
Added comments regarding centered and offset properties for sprite positioning.