### PR TITLE
Update world_village.tscn

### DIFF
--- a/VikingSagaProject/buildings/world_village.tscn
+++ b/VikingSagaProject/buildings/world_village.tscn
@@ -1,41 +1,47 @@
 [gd_scene load_steps=4 format=3 uid="uid://b70osvalqleu2"]
 
+[ext_resource type="Texture2D" path="res://assets/TilesetHouse.png" id="1"]
+
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_jevw3"]
 radius = 80.0
 height = 160.0
 
-[sub_resource type="Resource" id="Resource_558bg"]
-metadata/__load_path__ = "res://assets/TilesetHouse.png"
-
 [sub_resource type="CircleShape2D" id="CircleShape2D_5sf0l"]
 radius = 24.0
 
-[node name="world_village" type="StaticBody2D"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_village"]
+atlas = ExtResource("1")
+region = Rect2(0, 0, 48, 46)
+
+[node name="world_village" type="StaticBody2D" groups=["villages"]]
 z_index = 1
 collision_layer = 2
 collision_mask = 2
+editor_description = "Village POI: static collision + hover/interaction hitbox"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 visible = false
 shape = SubResource("CapsuleShape2D_jevw3")
 
 [node name="sprite" type="Sprite2D" parent="."]
-texture_filter = 1
 position = Vector2(0, -15)
-texture = SubResource("Resource_558bg")
-region_enabled = true
-region_rect = Rect2(0, 0, 48, 46)
+texture_filter = 1
+texture = SubResource("AtlasTexture_village")
+centered = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 
 [node name="villageHitbox" type="Area2D" parent="."]
 position = Vector2(0, -24)
+monitorable = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="villageHitbox"]
 position = Vector2(0, 8)
 shape = SubResource("CircleShape2D_5sf0l")
 
 [node name="Identity" type="Label" parent="."]
+position = Vector2(0, -52)
 offset_right = 40.0
 offset_bottom = 23.0
+horizontal_alignment = 1
 text = "Village"


### PR DESCRIPTION
Proper texture setup (no generic Resource)
Replaced the ad‑hoc Resource_558bg with an [ext_resource] Texture2D and an AtlasTexture sub‑resource. This is the correct way for Sprite2D.texture in Godot 4 when using a region from a spritesheet. It also keeps load_steps=4 (1 ext + 3 subs).

Removed redundant Sprite region flags
Since AtlasTexture already defines the crop area, region_enabled / region_rect on Sprite2D are no longer needed and were removed to avoid conflicts.

Fixed a parse error in Label
text = "Village"" → text = "Village". Also centered the label and nudged it above the sprite (position = Vector2(0, -52)) for readability.

Added a group for convenience
Root node now belongs to groups=["villages"], making it trivial to fetch all villages at runtime (get_tree().get_nodes_in_group("villages")).

Editor QoL
Added editor_description on the root to document the node’s purpose when working in the editor.

Hitbox is monitorable
Set villageHitbox.monitorable = true (explicit) so other Area2Ds can detect entering/exiting it even if they’re not monitoring themselves.

Preserved physics & drawing behavior
Kept your StaticBody2D layers/masks, overall z ordering, and both collision shapes (capsule for world collision; circle for the interaction area). Node names and hierarchy are unchanged to avoid breaking existing scripts.